### PR TITLE
feat: implement MongoDB schema

### DIFF
--- a/ayusin-be/.gitignore
+++ b/ayusin-be/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env.*
 .env
+bun.lockb

--- a/ayusin-be/package.json
+++ b/ayusin-be/package.json
@@ -20,6 +20,7 @@
     "drizzle-zod": "^0.8.3",
     "hono": "^4.9.8",
     "hono-pino": "^0.10.2",
+    "mongoose": "^8.18.1",
     "pg": "^8.16.3",
     "pino-pretty": "^13.1.1",
     "stoker": "^2.0.1",

--- a/ayusin-be/src/config/db.ts
+++ b/ayusin-be/src/config/db.ts
@@ -1,0 +1,14 @@
+import * as mongoose from "mongoose";
+
+export async function connectDB(mongoUri: string) {
+	try {
+		const conn = await mongoose.connect(mongoUri, {
+			autoIndex: true,
+		});
+
+		console.log(`MongoDB connected to ${conn.connection.host}`);
+	} catch (err) {
+		console.log(`MongoDB connection error: ${err}`);
+		process.exit(1);
+	}
+}

--- a/ayusin-be/src/env.ts
+++ b/ayusin-be/src/env.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 const EnvSchema = z.object({
 	PORT: z.string().default("3000").describe("Port"),
 	LOG_LEVEL: z.string().optional().default("info").describe("Log Level"),
+	MONGODB_URI: z.string().describe("Connection string to MongoDB"),
 	// CLERK_SECRET_KEY: z.string().describe("Clerk Secret Key"),
 	// CLERK_JWT_PUBLIC_KEY: z.string().describe("Clerk JWT Public Key"),
 	// DATABASE_CONNECTION_STRING: z
@@ -12,12 +13,12 @@ const EnvSchema = z.object({
 
 export type Env = z.infer<typeof EnvSchema>;
 
-const { data: env, error } = EnvSchema.safeParse(process.env);
+const result = EnvSchema.safeParse(process.env);
 
-if (error) {
-	console.error("Invalid environment variables: ", error);
-	console.error(z.flattenError(error));
+if (!result.success) {
+	console.error("Invalid environment variables: ", result.error);
+	console.error(z.flattenError(result.error));
 	process.exit(1);
 }
 
-export default env;
+export default result.data;

--- a/ayusin-be/src/index.ts
+++ b/ayusin-be/src/index.ts
@@ -2,8 +2,11 @@ import { serve } from "bun";
 
 import app from "./app";
 import env from "./env";
+import { connectDB } from "./config/db";
 
-const port = env?.PORT;
+const port = env.PORT;
+
+connectDB(env.MONGODB_URI);
 
 console.log(`🚀 Server starting on PORT ${port}...`);
 

--- a/ayusin-be/src/models/comment.model.ts
+++ b/ayusin-be/src/models/comment.model.ts
@@ -1,0 +1,21 @@
+import * as mongoose from "mongoose";
+
+export const commentSchema = new mongoose.Schema(
+	{
+		version: { type: String, required: true },
+		text: { type: String, required: true },
+		upvotes: { type: Number, required: true, default: 0 },
+		userID: {
+			type: mongoose.Schema.Types.ObjectId,
+			required: true,
+		},
+		reportID: {
+			type: mongoose.Schema.Types.ObjectId,
+			required: true,
+		},
+	},
+	{ timestamps: true },
+);
+
+export type Comment = mongoose.InferSchemaType<typeof commentSchema>;
+export const Comment = mongoose.model("Comment", commentSchema);

--- a/ayusin-be/src/models/index.ts
+++ b/ayusin-be/src/models/index.ts
@@ -1,0 +1,4 @@
+export { Report } from "./report.model";
+export { Upvote } from "./upvote.model";
+export { Comment } from "./comment.model";
+export { User } from "./user.model";

--- a/ayusin-be/src/models/point.model.ts
+++ b/ayusin-be/src/models/point.model.ts
@@ -1,0 +1,16 @@
+import * as mongoose from "mongoose";
+
+export const pointSchema = new mongoose.Schema({
+	type: {
+		type: String,
+		enum: ["Point"],
+		required: true,
+	},
+	coordinates: {
+		type: [Number],
+		required: true,
+	},
+});
+
+export type Point = mongoose.InferSchemaType<typeof pointSchema>;
+export const Point = mongoose.model("Point", pointSchema);

--- a/ayusin-be/src/models/report.model.ts
+++ b/ayusin-be/src/models/report.model.ts
@@ -1,0 +1,39 @@
+import * as mongoose from "mongoose";
+import { pointSchema } from "./point.model";
+
+export const reportSchema = new mongoose.Schema(
+	{
+		version: { type: String, required: true },
+		title: { type: String, required: true },
+		description: { type: String, required: false },
+		labels: { type: [String], required: false },
+		location: {
+			type: pointSchema,
+			required: true,
+		},
+		history: { type: [mongoose.Schema.Types.ObjectId], required: true },
+		upvotes: { type: Number, required: true, default: 0 },
+		metadata: {
+			mediaLinks: { type: [String], required: true },
+			scope: {
+				type: String,
+				enum: ["Barangay", "City", "Province", "Regional", "National"],
+				required: true,
+			},
+			categories: { type: [String], required: true },
+			dateClosed: { type: mongoose.Schema.Types.Date, required: false },
+			assignedDepartmentIDs: {
+				type: [mongoose.Schema.Types.ObjectId],
+				required: true,
+			},
+			assignedPersonnelIDs: {
+				type: [mongoose.Schema.Types.ObjectId],
+				required: true,
+			},
+		},
+	},
+	{ timestamps: true },
+);
+
+export type Report = mongoose.InferSchemaType<typeof reportSchema>;
+export const Report = mongoose.model("Report", reportSchema);

--- a/ayusin-be/src/models/upvote.model.ts
+++ b/ayusin-be/src/models/upvote.model.ts
@@ -1,0 +1,19 @@
+import * as mongoose from "mongoose";
+
+export const upvoteSchema = new mongoose.Schema(
+	{
+		version: { type: String, required: true },
+		userID: {
+			type: mongoose.Schema.Types.ObjectId,
+			required: true,
+		},
+		reportID: {
+			type: mongoose.Schema.Types.ObjectId,
+			required: true,
+		},
+	},
+	{ timestamps: true },
+);
+
+export type Upvote = mongoose.InferSchemaType<typeof upvoteSchema>;
+export const Upvote = mongoose.model("Upvote", upvoteSchema);

--- a/ayusin-be/src/models/user.model.ts
+++ b/ayusin-be/src/models/user.model.ts
@@ -1,0 +1,13 @@
+import * as mongoose from "mongoose";
+
+export const userSchema = new mongoose.Schema(
+	{
+		version: { type: String, required: true },
+		type: { type: String, enum: ["Citizen", "LGU"], required: true },
+		clerkID: { type: String, required: true },
+	},
+	{ timestamps: true },
+);
+
+export type User = mongoose.InferSchemaType<typeof userSchema>;
+export const User = mongoose.model("User", userSchema);


### PR DESCRIPTION
- implement the initial database schemas with Mongoose, per the Linear document
  - schema changes in pre-production code is easy, even if the schema would change a lot
- add `MONGODB_URI` environment variable for MongoDB connections
- handle safe Zod parsing on `env.ts` properly ([see Zod documentation](https://zod.dev/basics?id=handling-errors)), narrowing the exported `env` variable's type from `Env | undefined` to `Env`, eliminating the need to do `env?` to access properties.
- add `bun.lockb` to `.gitignore`

## TODO

- [ ] add additional schemas
  - [ ] departments
  - [ ] reports_history 